### PR TITLE
feat(oss-special-bucket-policy): Add GetBucketPolicy permission to the special bucket policy

### DIFF
--- a/aliyun/ecs/ecs_ssrf/main.tf
+++ b/aliyun/ecs/ecs_ssrf/main.tf
@@ -1,10 +1,11 @@
 resource "alicloud_instance" "instance" {
   security_groups            = alicloud_security_group.group.*.id
-  instance_type              = data.alicloud_instance_types.types_ds.instance_types.0.id
+  instance_type              = "ecs.e-c1m1.large"
   image_id                   = "ubuntu_18_04_64_20G_alibase_20190624.vhd"
   instance_name              = "huocorp_terraform_goat_instance"
   vswitch_id                 = alicloud_vswitch.vswitch.id
-  system_disk_size           = 20
+  system_disk_size           = 40
+  system_disk_category = "cloud_essd"
   internet_max_bandwidth_out = 100
   user_data                  = <<EOF
 #!/bin/bash

--- a/aliyun/ecs/ecs_virtual_machine_disks_are_unencrypted/main.tf
+++ b/aliyun/ecs/ecs_virtual_machine_disks_are_unencrypted/main.tf
@@ -1,9 +1,10 @@
 resource "alicloud_instance" "instance" {
   security_groups  = alicloud_security_group.group.*.id
-  instance_type    = data.alicloud_instance_types.types_ds.instance_types.0.id
+  instance_type    = "ecs.e-c1m1.large"
   image_id         = "ubuntu_18_04_64_20G_alibase_20190624.vhd"
   vswitch_id       = alicloud_vswitch.vswitch.id
-  system_disk_size = 20
+  system_disk_size = 40
+  system_disk_category = "cloud_essd"
   instance_name    = "huocorp_terraform_goat_instance"
   depends_on = [
     alicloud_security_group.group,

--- a/aliyun/networking/vpc_security_group_open_all_ports/main.tf
+++ b/aliyun/networking/vpc_security_group_open_all_ports/main.tf
@@ -1,9 +1,10 @@
 resource "alicloud_instance" "instance" {
   security_groups  = alicloud_security_group.group.*.id
-  instance_type    = data.alicloud_instance_types.types_ds.instance_types.0.id
+  instance_type    = "ecs.e-c1m1.large"
   image_id         = "ubuntu_18_04_64_20G_alibase_20190624.vhd"
   vswitch_id       = alicloud_vswitch.vswitch.id
-  system_disk_size = 20
+  system_disk_size = 40
+  system_disk_category = "cloud_essd"
   instance_name    = "huocorp_terraform_goat_instance"
   depends_on = [
     alicloud_security_group.group,

--- a/aliyun/networking/vpc_security_group_open_common_ports/main.tf
+++ b/aliyun/networking/vpc_security_group_open_common_ports/main.tf
@@ -1,9 +1,10 @@
 resource "alicloud_instance" "instance" {
   security_groups  = alicloud_security_group.group.*.id
-  instance_type    = data.alicloud_instance_types.types_ds.instance_types.0.id
+  instance_type    = "ecs.e-c1m1.large"
   image_id         = "ubuntu_18_04_64_20G_alibase_20190624.vhd"
   vswitch_id       = alicloud_vswitch.vswitch.id
-  system_disk_size = 20
+  system_disk_size = 40
+  system_disk_category = "cloud_essd"
   instance_name    = "huocorp_terraform_goat_instance"
   depends_on = [
     alicloud_security_group.group,

--- a/aliyun/oss/special_bucket_policy/main.tf
+++ b/aliyun/oss/special_bucket_policy/main.tf
@@ -9,53 +9,69 @@ resource "alicloud_oss_bucket" "Create_Bucket" {
   force_destroy = true
   policy        = <<POLICY
 {
-	"Version": "1",
-	"Statement": [{
-		"Effect": "Allow",
-		"Action": [
-			"oss:GetObject",
-			"oss:GetObjectAcl",
-			"oss:ListObjects",
-			"oss:RestoreObject",
-			"oss:GetVodPlaylist",
-			"oss:ListObjectVersions",
-			"oss:GetObjectVersion",
-			"oss:GetObjectVersionAcl",
-			"oss:RestoreObjectVersion"
-		],
-		"Principal": [
-			"*"
-		],
-		"Resource": [
-			"acs:oss:*:*:*/*"
-		],
-		"Condition": {
-			"StringEquals": {
-          		"acs:UserAgent": [
-					"test"
-				]
-			}
-		}
-	}, {
-		"Effect": "Allow",
-		"Action": [
-			"oss:ListObjects",
-			"oss:GetObject"
-		],
-		"Principal": [
-			"*"
-		],
-		"Resource": [
-			"acs:oss:*:*:*"
-		],
-		"Condition": {
-			"StringEquals": {
-          		"acs:UserAgent": [
-					"HxSecurityLab"
-				]
-			}
-		}
-	}]
+    "Version": "1",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "oss:GetObject",
+                "oss:GetObjectAcl",
+                "oss:ListObjects",
+                "oss:RestoreObject",
+                "oss:GetVodPlaylist",
+                "oss:ListObjectVersions",
+                "oss:GetObjectVersion",
+                "oss:GetObjectVersionAcl",
+                "oss:RestoreObjectVersion"
+            ],
+            "Principal": [
+                "*"
+            ],
+            "Resource": [
+                "acs:oss:*:*:*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "acs:UserAgent": [
+                        "test"
+                    ]
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "oss:ListObjects",
+                "oss:GetObject"
+            ],
+            "Principal": [
+                "*"
+            ],
+            "Resource": [
+                "acs:oss:*:*:*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "acs:UserAgent": [
+                        "HxSecurityLab"
+                    ]
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "oss:GetBucketPolicy"
+            ],
+            "Principal": [
+                "*"
+            ],
+            "Resource": [
+                "acs:oss:*:*:*"
+            ],
+            "Condition": {}
+        }
+    ]
 }
 POLICY
 }


### PR DESCRIPTION
This commit adds the ability to get the bucket policy for all OSS buckets. The new policy allows any principal to perform the 'oss:GetBucketPolicy' action on all resources. The addition of this policy should not impact the main functionality of the system.

The following policy has been added:
{
  "Effect": "Allow",
  "Action": [
    "oss:GetBucketPolicy"
  ],
  "Principal": [
    "*"
  ],
  "Resource": [
    "acs:oss:*:*:*"
  ],
  "Condition": {}
}